### PR TITLE
BOJ11653 python, kotlin 풀이 추가

### DIFF
--- a/week1/GamGomYang/BOJ11653.kt
+++ b/week1/GamGomYang/BOJ11653.kt
@@ -1,0 +1,15 @@
+fun main() {
+    val number = readLine()!!.toInt()
+    var n = number
+    var i = 2
+
+    while (n > 1) {
+        if (n % i == 0) {
+            n /= i
+            println(i)
+            i = 2
+        } else {
+            i += 1
+        }
+    }
+}

--- a/week1/GamGomYang/BOJ11653.py
+++ b/week1/GamGomYang/BOJ11653.py
@@ -1,0 +1,15 @@
+from typing import Sequence, Any
+
+number = int(input())
+i=2
+
+while(number>1):
+    if (number%i == 0):
+        number = number/i
+        print(i)
+        i=2
+    else:
+        i +=1
+
+
+        

--- a/week1/GamGomYang/BOJ1182.py
+++ b/week1/GamGomYang/BOJ1182.py
@@ -1,0 +1,21 @@
+def Solution(arr, n, s):
+    def dfs(idx, current_sum):
+        nonlocal count
+        if idx == n:  
+            return
+        current_sum += arr[idx] 
+        if current_sum == s:
+            count += 1
+        dfs(idx + 1, current_sum) 
+        dfs(idx + 1, current_sum - arr[idx])  
+
+    count = 0
+    dfs(0, 0)
+    return count
+
+
+n, s = map(int, input().split())
+arr = list(map(int, input().split()))
+
+
+print(Solution(arr, n, s))

--- a/week1/GamGomYang/LTC2614.py
+++ b/week1/GamGomYang/LTC2614.py
@@ -1,0 +1,31 @@
+from typing import List
+
+class Solution:
+    def prime_machine(self, num: int) -> bool:
+        if num <= 1:
+            return False
+        if num <= 3:
+            return True
+        if num % 2 == 0 or num % 3 == 0:
+            return False
+        i = 5
+        while i * i <= num:
+            if num % i == 0 or num % (i + 2) == 0:
+                return False
+            i += 6
+        return True
+
+    def diagonalPrime(self, nums: List[List[int]]) -> int:
+        n = len(nums)
+        diagonals = set()
+
+        for i in range(n):
+            diagonals.add(nums[i][i])           
+            diagonals.add(nums[i][n - i - 1])   
+
+        prime_numbers = [num for num in diagonals if self.prime_machine(num)]
+        return max(prime_numbers) if prime_numbers else 0
+
+solution = Solution()
+print(solution.diagonalPrime([[1, 2, 3], [5, 6, 7], [9, 10, 11]]))  
+print(solution.diagonalPrime([[1, 2, 3], [5, 17, 7], [9, 11, 10]]))  


### PR DESCRIPTION
Title: BOJ11653 문제 풀이 추가
[0703] BOJ1182 문제 풀이 추가

Description:

BOJ11653 문제를 Python과 Kotlin으로 풀이하였습니다.

문제 풀이 과정:

처음에는 어제 풀었던 소수 판별 알고리즘을 이용해서 소수를 생성한 후, 해당 소수로 입력값을 나누는 방식으로 풀어보려고 했습니다. 하지만 코드가 복잡해지는 문제점이 있었습니다.
그래서 첫 번째 소수인 2부터 나머지 연산으로 판별 후 나머지가 없으면 소인수분해를 하고, 해당 소수를 출력했습니다. 나머지가 있으면 +1을 하여 다시 나머지 연산을 판별하는 알고리즘을 작성했습니다.
해당 알고리즘에서 생각해볼 만한 점:

Q1: 처음에 이렇게 작성하면 소수가 아닌 수가 나머지 판별만 통과하면 출력되는 오류가 발생하지 않을까요?
A1: 이러한 오류는 발생하지 않습니다. 예를 들어, 인수가 나머지 판별을 거듭하며 1씩 추가되어 6이 된다고 가정해봅시다. 애초에 6은 2*3이므로 6까지 도달하기도 전에 2와 3에서 나머지 판별이 되어 출력됩니다. 즉, 소수가 아닌 숫자는 출력되지 않습니다.

